### PR TITLE
Fix hex generation when bits < 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-generator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generates a random hexadecimal string given the number of bits to generate.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = function(bits) {
 	let hex = '';
 
 	if (remainder) {
-		hex = Math.floor(Math.random() * (2 ^ remainder - 1)).toString(16);
+		hex = Math.floor(Math.random() * (1 << remainder)).toString(16);
 	}
 
 	for (let i = 0; i < nibbles; i++) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,6 +19,11 @@ describe('Hexadecimal Generator', () => {
 		expect(result).to.match(/^[a-f0-9]+$/i).and.to.have.a.lengthOf(64);
 	});
 
+	it('Generates a 1-bit string', () => {
+		const result = hexgen(1);
+		expect(result).to.match(/^[01]$/i).and.to.have.a.lengthOf(1);
+	})
+
 	it('Generates a 24-bit string', () => {
 		const result = hexgen(24);
 		expect(result).to.match(/^[a-f0-9]+$/i).and.to.have.a.lengthOf(6);


### PR DESCRIPTION
- This commit changes the functionality of the remaining bits (bits < 4 bits in length) to correctly calculate a random bit value between `0` and the remaining bit value `(0 - 3)`

This should fix #1 , if you're interested in someone rewriting the interface to include a deterministic way to generate test input (as referenced in #1) I'm more than happy to give it a go 👍 